### PR TITLE
git → https protocol in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ $('#my-modal').on('shown.bs.modal', function (event) {
 
 ## History
 
+* **2.0.5**: Fixing `npm install` issue ([#28](https://github.com/cloudfour/hideShowPassword/issues/28))
 * **2.0.4**: Namespaced events ([#20](https://github.com/cloudfour/hideShowPassword/issues/20)), [npm](https://www.npmjs.com/) support ([#21](https://github.com/cloudfour/hideShowPassword/issues/21))
 * **2.0.3**: Removed errant `console.log` call ([#13](https://github.com/cloudfour/hideShowPassword/issues/13))
 * **2.0.2**: `className` option now instantiates on `init` ([#11](https://github.com/cloudfour/hideShowPassword/issues/11))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hideShowPassword",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Easily reveal or hide password field contents via JavaScript or a nifty inner toggle button. Supports touch quite nicely!",
   "main": "hideShowPassword.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/cloudfour/hideShowPassword.git"
+    "url": "https://github.com/cloudfour/hideShowPassword.git"
   },
   "keywords": [
     "form",


### PR DESCRIPTION
This PR attempts to resolve #28 by revising the `repository.url` field to use the same protocol as that in [Leveller](https://github.com/cloudfour/leveller) (which does not seem to have the same issue). It also bumps the version number since NPM [no longer allows](http://blog.npmjs.org/post/77758351673/no-more-npm-publish-f) `publish -f`. (The release will still need to be tagged post-merge.)