### PR TITLE
Broaden jQuery dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ $('#my-modal').on('shown.bs.modal', function (event) {
 
 ## History
 
+* **2.0.8**: Fixing bloated bundles bug ([#39](https://github.com/cloudfour/hideShowPassword/issues/39))
 * **2.0.7**: Fixing `inheritStyles` bug ([#34](https://github.com/cloudfour/hideShowPassword/issues/34))
 * **2.0.6**: Revising npm package name ([#28](https://github.com/cloudfour/hideShowPassword/issues/28))
 * **2.0.5**: Revising npm package repo URL ([#28](https://github.com/cloudfour/hideShowPassword/issues/28))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hideshowpassword",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Easily reveal or hide password field contents via JavaScript or a nifty inner toggle button. Supports touch quite nicely!",
   "main": "hideShowPassword.js",
   "scripts": {
@@ -27,7 +27,7 @@
   },
   "homepage": "http://cloudfour.github.io/hideShowPassword/",
   "dependencies": {
-    "jquery": "^2.1.3"
+    "jquery": ">=1.11"
   },
   "devDependencies": {
     "uglify-js": "^2.4.17"


### PR DESCRIPTION
This resolves #39 (see that issue for confirmation from existing reporter) by updating the jQuery dependency version, allowing for either `1.x` or `2.x` versions to be used without duplicate dependencies in the resulting Browserify bundle.