### PR TITLE
Use distinct bower.json instead of symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ $('#my-modal').on('shown.bs.modal', function (event) {
 
 ## History
 
+* **2.0.11**: Fix for Bower install on Windows ([#44](https://github.com/cloudfour/hideShowPassword/issues/44))
 * **2.0.10**: Update Modernizr test ([#42](https://github.com/cloudfour/hideShowPassword/issues/42))
 * **2.0.9**: Add `title` attributes to toggle by default ([#41](https://github.com/cloudfour/hideShowPassword/pull/41))
 * **2.0.8**: Fixing bloated bundles bug ([#39](https://github.com/cloudfour/hideShowPassword/issues/39))

--- a/bower.json
+++ b/bower.json
@@ -1,1 +1,36 @@
-package.json
+{
+  "name": "hideshowpassword",
+  "version": "2.0.11",
+  "description": "Easily reveal or hide password field contents via JavaScript or a nifty inner toggle button. Supports touch quite nicely!",
+  "main": "hideShowPassword.js",
+  "scripts": {
+    "minify": "uglifyjs hideShowPassword.js -o hideShowPassword.min.js",
+    "update:bower": "cp package.json bower.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudfour/hideShowPassword.git"
+  },
+  "keywords": [
+    "form",
+    "forms",
+    "input",
+    "inputs",
+    "password",
+    "visibility",
+    "jquery-plugin",
+    "ecosystem:jquery"
+  ],
+  "author": "Cloud Four",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/cloudfour/hideShowPassword/issues"
+  },
+  "homepage": "http://cloudfour.github.io/hideShowPassword/",
+  "dependencies": {
+    "jquery": ">=1.11"
+  },
+  "devDependencies": {
+    "uglify-js": "^2.4.17"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "hideshowpassword",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Easily reveal or hide password field contents via JavaScript or a nifty inner toggle button. Supports touch quite nicely!",
   "main": "hideShowPassword.js",
   "scripts": {
-    "minify": "uglifyjs hideShowPassword.js -o hideShowPassword.min.js"
+    "minify": "uglifyjs hideShowPassword.js -o hideShowPassword.min.js",
+    "update:bower": "cp package.json bower.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #44 

Since `v2.0.4` we've used a symbolic link for `bower.json` to reference `package.json`. This was done to ease maintenance.

Unfortunately, symlinks behave fundamentally differently between Unix and Windows. Bower would read the actual text content of the symlink (`package.json`) and report to fail at the first character (`p`).

This restores `bower.json`, while also adding an NPM script to make updating it in the future easier.

In a future breaking version, we should consider ditching Bower entirely for NPM.

---

@erikjung @mrgerardorodriguez 