### PR TITLE
Add focusAfterToggle:boolean option to focus element after toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,10 @@ Here are all of the available options and their defaults:
   // set after input has been inserted into the DOM.
   enable: canSetInputAttribute,
 
-  // Set to true to focus the cursor in the input element after
-  // the element has been toggled. Benefitial for those who are
-  // typing out a password and just want to check their value
-  // and retain the focus of the input.
-  focusAfterToggle: false,
+  // Event to trigger whenever the element is toggled.
+  // For example, if 'focus' it will focus the cursor in the
+  // input element after toggling.
+  triggerOnToggle: '',
 
   // Class to add to input element when the plugin is enabled.
   className: 'hideShowPassword-field',

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Here are all of the available options and their defaults:
   // set after input has been inserted into the DOM.
   enable: canSetInputAttribute,
 
+  // Set to true to focus the cursor in the input element after
+  // the element has been toggled. Benefitial for those who are
+  // typing out a password and just want to check their value
+  // and retain the focus of the input.
+  focusAfterToggle: false,
+
   // Class to add to input element when the plugin is enabled.
   className: 'hideShowPassword-field',
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Here are all of the available options and their defaults:
   // Event to trigger whenever the element is toggled.
   // For example, if 'focus' it will focus the cursor in the
   // input element after toggling.
-  triggerOnToggle: '',
+  triggerOnToggle: false,
 
   // Class to add to input element when the plugin is enabled.
   className: 'hideShowPassword-field',

--- a/hideShowPassword.js
+++ b/hideShowPassword.js
@@ -55,7 +55,7 @@
     // Event to trigger whenever the element is toggled.
     // For example, if 'focus' it will focus the cursor in the
     // input element after toggling.
-    triggerOnToggle: '',
+    triggerOnToggle: false,
 
     // Class to add to input element when the plugin is enabled.
     className: 'hideShowPassword-field',
@@ -280,7 +280,9 @@
         .prop($.extend({}, this.options.props, this.state().props))
         .addClass(this.state().className)
         .removeClass(this.otherState().className);
-      this.element.trigger(this.options.triggerOnToggle, [ this ]);
+      if (this.options.triggerOnToggle) {
+        this.element.trigger(this.options.triggerOnToggle, [ this ]);
+      }
       this.updateToggle();
       return true;
     },

--- a/hideShowPassword.js
+++ b/hideShowPassword.js
@@ -52,6 +52,12 @@
     // set after input has been inserted into the DOM.
     enable: canSetInputAttribute,
 
+    // Set to true to focus the cursor in the input element after
+    // the element has been toggled. Benefitial for those who are
+    // typing out a password and just want to check their value
+    // and retain the focus of the input.
+    focusAfterToggle: false,
+
     // Class to add to input element when the plugin is enabled.
     className: 'hideShowPassword-field',
 
@@ -163,9 +169,9 @@
         toggle: {
           className: 'hideShowPassword-toggle-hide',
           content: 'Hide',
-          attr: { 
+          attr: {
             'aria-pressed': 'true',
-            title: 'Hide Password' 
+            title: 'Hide Password'
           }
         }
       },
@@ -176,7 +182,7 @@
         toggle: {
           className: 'hideShowPassword-toggle-show',
           content: 'Show',
-          attr: { 
+          attr: {
             'aria-pressed': 'false',
             title: 'Show Password'
           }
@@ -275,6 +281,11 @@
         .prop($.extend({}, this.options.props, this.state().props))
         .addClass(this.state().className)
         .removeClass(this.otherState().className);
+
+      if (this.options.focusAfterToggle) {
+        this.element.focus();
+      }
+
       this.updateToggle();
       return true;
     },

--- a/hideShowPassword.js
+++ b/hideShowPassword.js
@@ -52,11 +52,10 @@
     // set after input has been inserted into the DOM.
     enable: canSetInputAttribute,
 
-    // Set to true to focus the cursor in the input element after
-    // the element has been toggled. Benefitial for those who are
-    // typing out a password and just want to check their value
-    // and retain the focus of the input.
-    focusAfterToggle: false,
+    // Event to trigger whenever the element is toggled.
+    // For example, if 'focus' it will focus the cursor in the
+    // input element after toggling.
+    triggerOnToggle: '',
 
     // Class to add to input element when the plugin is enabled.
     className: 'hideShowPassword-field',
@@ -281,11 +280,7 @@
         .prop($.extend({}, this.options.props, this.state().props))
         .addClass(this.state().className)
         .removeClass(this.otherState().className);
-
-      if (this.options.focusAfterToggle) {
-        this.element.focus();
-      }
-
+      this.element.trigger(this.options.triggerOnToggle, [ this ]);
       this.updateToggle();
       return true;
     },


### PR DESCRIPTION
Awesome plugin, saved me from having to write my own!

I think most users will be focused in the text/password field entering input when they toggle the show/hide; I think it would be a good idea to allow an option to retain focus on the input element after toggling.

Default behavior does not change anything, must set the option in order for any effect to occur.

Did not update any version/scripts in case you all had a specific way you wanted to bump those.